### PR TITLE
Fixed crash when Particle::Draw called without Particle::Tick

### DIFF
--- a/actor.h
+++ b/actor.h
@@ -80,7 +80,7 @@ public:
 	void Remove() { sprite.Remove(); }
 	void Tick();
 	void Draw() { sprite.Draw( Map::bitmap, pos, frame ); }
-	uint backup[4], color = 0, frame, frameChange;
+	uint backup[4], color = 0, frame = 0, frameChange;
 	bool hasBackup = false;
 	SpriteInstance sprite;
 	float2 pos, dir;


### PR DESCRIPTION
frame property initialized to 0 in the header file, so Particle::Tick does not need to be called before Particle::Draw in order to define the property.